### PR TITLE
Update glutin to newest version 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["rendering"]
 readme = "README.md"
 
 [dependencies]
-glutin = "0.17.0"
+glutin = "0.19.0"
 gl = "0.10.0"
 rustic_gl = "0.3.2"


### PR DESCRIPTION
Currently glutin(v0.17.0) is not able to receive HoveredFile and HoveredFileCancelled Events.
This has been fixed in winit in tomaka/winit#662

Glutin 0.19.0 is the first (and latest) version with this bugfix.
Bumping the version is enought to get these event working and it does not break any functionality of this crate.