### PR TITLE
Use EventLoopWindowTarget

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -10,7 +10,7 @@ use gl::types::*;
 
 use std::mem::size_of_val;
 use glutin::window::WindowBuilder;
-use glutin::event_loop::{EventLoop, ControlFlow};
+use glutin::event_loop::{EventLoop, ControlFlow, EventLoopWindowTarget};
 use glutin::platform::run_return::EventLoopExtRunReturn;
 use glutin::event::{Event, WindowEvent, VirtualKeyCode, ElementState, KeyboardInput, StartCause};
 use std::time::Instant;
@@ -21,7 +21,7 @@ pub fn init_glutin_context<S: ToString, ET: 'static>(
     window_width: f64,
     window_height: f64,
     resizable: bool,
-    event_loop: &EventLoop<ET>
+    event_loop: &EventLoopWindowTarget<ET>
 ) -> WindowedContext<PossiblyCurrent> {
     let window_size = LogicalSize::new(window_width, window_height);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub use config::{Config, ConfigBuilder};
 pub use core::{Internal, BufferFormat, Framebuffer};
 
 use core::ToGlType;
-use glutin::event_loop::EventLoop;
+use glutin::event_loop::{EventLoop, EventLoopWindowTarget};
 use glutin::dpi::LogicalSize;
 
 /// Creates a non-resizable window and framebuffer with a given size in logical pixels. On HiDPI
@@ -153,7 +153,7 @@ pub fn gotta_go_fast<S: ToString>(
 /// `get_fancy` with a custom config. However, if there is a bug in the OS/windowing system or
 /// glutin or in this library, this function exists as a possible work around (or in case for some
 /// reason everything must be absolutely correct at window creation)
-pub fn get_fancy<ET: 'static>(config: Config, event_loop: &EventLoop<ET>) -> MiniGlFb {
+pub fn get_fancy<ET: 'static>(config: Config, event_loop: &EventLoopWindowTarget<ET>) -> MiniGlFb {
     let buffer_size = config.buffer_size.unwrap_or_else(|| config.window_size.cast());
 
     let context = core::init_glutin_context(


### PR DESCRIPTION
I'm a total idiot for not doing this during #5. Basically the current type only allows you to create windows while the application is not already running, which is not ideal. Probably a breaking change but whatever